### PR TITLE
Update to KSPCPM

### DIFF
--- a/SSAUCE/Extras/ChuteAutoCut.cfg
+++ b/SSAUCE/Extras/ChuteAutoCut.cfg
@@ -1,17 +1,17 @@
-@PART[MRMainChute]:NEEDS[Bluedog_DB]
+@PART[MRMainChute]:NEEDS[KSPCommunityPartModules]
 {
 	MODULE
 	{
-		name = ModuleBdbCutDrogue
+		name = ModuleAutoCutDrogue
 		isDrogueChute = false
 		autoCutDrogue = true
 	}
 }
-@PART[MRDrogue]:NEEDS[Bluedog_DB]
+@PART[MRDrogue]:NEEDS[KSPCommunityPartModules]
 {
 	MODULE
 	{
-		name = ModuleBdbCutDrogue
+		name = ModuleAutoCutDrogue
 		isDrogueChute = true
 	}
 }


### PR DESCRIPTION
Hey there, 

BDB's auto cut drogue module has moved and is now being housed under the KSPCommunityPartModules umbrella.
This means that your patch to add BDB's module to your parts will no longer work when BDB updates to `v1.14.1`. See [here](https://github.com/CobaltWolf/Bluedog-Design-Bureau/pull/1570)

I've therefore made the neccecary adjustments to your patch for it to continue working as expected.
If you accept these changes, it is recommend to declare a new dependency on KSPCommunityPartModules, but not required.